### PR TITLE
新規PR作成時にDraftで作成するように変更

### DIFF
--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -144,6 +144,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           path: target-repo
           branch: update-openapi-schema
+          draft: true
           title: "Update OpenAPI schema"
           body: |
             This PR updates the OpenAPI schema from [dotto-typespec](https://github.com/fun-dotto/dotto-typespec).


### PR DESCRIPTION
## Summary
- create-pr ワークフローで新規PRを作成する際に `draft: true` を設定し、ドラフトPRとして作成するように変更

## Test plan
- [ ] ワークフローが正常に動作し、ドラフトPRが作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Close #26 