### PR TITLE
Add timetable and course registration APIs to app BFF

### DIFF
--- a/src/academic-api/model.tsp
+++ b/src/academic-api/model.tsp
@@ -24,7 +24,7 @@ namespace AcademicService {
   }
 
   model SubjectFaculty {
-    facultyId: string;
+    faculty: Faculty;
     isPrimary: boolean;
   }
 
@@ -232,7 +232,7 @@ namespace AcademicService {
   model CourseRegistration {
     id: string;
     userId: string;
-    subjectId: string;
+    subject: SubjectSummary;
   }
 
   model CourseRegistrationRequest {
@@ -244,17 +244,15 @@ namespace AcademicService {
 
   model TimetableItem {
     id: string;
-    subjectId: string;
+    subject: SubjectSummary;
     dayOfWeek: DottoFoundationV1.DayOfWeek;
     period: DottoFoundationV1.Period;
-    roomId: string;
   }
 
   model TimetableItemRequest {
     subjectId: string;
     dayOfWeek: DottoFoundationV1.DayOfWeek;
     period: DottoFoundationV1.Period;
-    roomId: string;
   }
 
   // Facility 系

--- a/src/app-bff-api/model.tsp
+++ b/src/app-bff-api/model.tsp
@@ -75,4 +75,20 @@ namespace AppBFFService {
     course?: DottoFoundationV1.Course;
     class?: DottoFoundationV1.Class;
   }
+
+  model TimetableItem {
+    id: string;
+    subject: SubjectSummary;
+    dayOfWeek: DottoFoundationV1.DayOfWeek;
+    period: DottoFoundationV1.Period;
+  }
+
+  model CourseRegistration {
+    id: string;
+    subject: SubjectSummary;
+  }
+
+  model CourseRegistrationRequest {
+    subjectId: string;
+  }
 }

--- a/src/app-bff-api/service.tsp
+++ b/src/app-bff-api/service.tsp
@@ -108,4 +108,61 @@ namespace AppBFFService {
         user: UserInfo;
       }>;
   }
+
+  @route("/v1/timetableItems")
+  @tag("TimetableItems")
+  interface TimetableItemsV1 {
+    /**
+     * 時間割を取得する
+     *
+     * @param year 開講年度; 指定しない場合は今年度が選択される
+     * @param semester 開講時期
+     * @param dayOfWeek 曜日; 複数指定時はORでフィルタリングされる; 指定しない場合は全ての曜日が選択される
+     * @returns 時間割のリスト
+     */
+    @get list(
+      @query year?: integer,
+      @query semester: DottoFoundationV1.CourseSemester,
+      @query dayOfWeek?: DottoFoundationV1.DayOfWeek[],
+    ): OkResponse &
+      Body<{
+        timetableItems: TimetableItem[];
+      }>;
+  }
+
+  @route("/v1/courseRegistrations")
+  @tag("CourseRegistrations")
+  interface CourseRegistrationsV1 {
+    /**
+     * 履修情報を取得する
+     * @param userId ユーザーID
+     * @param year 開講年度; 指定しない場合は今年度が選択される
+     * @param semester 開講時期
+     * @returns 履修情報のリスト
+     */
+    @get list(
+      @query year?: integer,
+      @query semester: DottoFoundationV1.CourseSemester,
+    ): OkResponse &
+      Body<{
+        courseRegistrations: CourseRegistration[];
+      }>;
+
+    /**
+     * 履修情報を作成する
+     * @param body 作成する履修情報の情報
+     * @returns 作成された履修情報
+     */
+    @post create(@body body: CourseRegistrationRequest): CreatedResponse &
+      Body<{
+        courseRegistration: CourseRegistration;
+      }>;
+
+    /**
+     * 履修情報を削除する
+     * @param id 履修情報ID
+     * @returns 削除された履修情報
+     */
+    @delete delete(@path id: string): NoContentResponse;
+  }
 }


### PR DESCRIPTION
## Summary
- add timetable item and course registration endpoints to App BFF API
- expose SubjectSummary and Faculty references in Academic API models instead of raw IDs where needed
- remove roomId from timetable item/request models to match the new schema

## Verification
- pnpm compile