### PR TITLE
app-bff-api に休講・補講・教室変更の一覧取得を追加

### DIFF
--- a/src/app-bff-api/model.tsp
+++ b/src/app-bff-api/model.tsp
@@ -95,6 +95,40 @@ namespace AppBFFService {
     credit: integer;
   }
 
+  /**
+   * 休講
+   */
+  model CancelledClass {
+    id: string;
+    subject: SubjectSummary;
+    date: plainDate;
+    period: DottoFoundationV1.Period;
+    comment: string;
+  }
+
+  /**
+   * 補講
+   */
+  model MakeupClass {
+    id: string;
+    subject: SubjectSummary;
+    date: plainDate;
+    period: DottoFoundationV1.Period;
+    comment: string;
+  }
+
+  /**
+   * 教室変更
+   */
+  model RoomChange {
+    id: string;
+    subject: SubjectSummary;
+    date: plainDate;
+    period: DottoFoundationV1.Period;
+    originalRoom: Room;
+    newRoom: Room;
+  }
+
   model TimetableItem {
     id: string;
     subject: SubjectSummary;

--- a/src/app-bff-api/service.tsp
+++ b/src/app-bff-api/service.tsp
@@ -89,6 +89,66 @@ namespace AppBFFService {
       }>) | UnauthorizedResponse;
   }
 
+  @route("/v1/cancelledClasses")
+  @tag("CancelledClasses")
+  interface CancelledClassesV1 {
+    /**
+     * 休講一覧を取得する
+     * @param subjectIds 科目IDのリスト; 指定した科目の休講のみを取得する; 指定しない場合は全科目を検索対象とする
+     * @param from 検索対象開始日付
+     * @param until 検索対象終了日付
+     * @returns 休講のリスト
+     */
+    @get list(
+      @query subjectIds?: string[],
+      @query(#{ explode: true }) from?: plainDate,
+      @query(#{ explode: true }) until?: plainDate,
+    ): (OkResponse &
+      Body<{
+        cancelledClasses: CancelledClass[];
+      }>) | UnauthorizedResponse;
+  }
+
+  @route("/v1/makeupClasses")
+  @tag("MakeupClasses")
+  interface MakeupClassesV1 {
+    /**
+     * 補講一覧を取得する
+     * @param subjectIds 科目IDのリスト; 指定した科目の補講のみを取得する; 指定しない場合は全科目を検索対象とする
+     * @param from 検索対象開始日付
+     * @param until 検索対象終了日付
+     * @returns 補講のリスト
+     */
+    @get list(
+      @query subjectIds?: string[],
+      @query(#{ explode: true }) from?: plainDate,
+      @query(#{ explode: true }) until?: plainDate,
+    ): (OkResponse &
+      Body<{
+        makeupClasses: MakeupClass[];
+      }>) | UnauthorizedResponse;
+  }
+
+  @route("/v1/roomChanges")
+  @tag("RoomChanges")
+  interface RoomChangesV1 {
+    /**
+     * 教室変更一覧を取得する
+     * @param subjectIds 科目IDのリスト; 指定した科目の教室変更のみを取得する; 指定しない場合は全科目を検索対象とする
+     * @param from 検索対象開始日付
+     * @param until 検索対象終了日付
+     * @returns 教室変更のリスト
+     */
+    @get list(
+      @query subjectIds?: string[],
+      @query(#{ explode: true }) from?: plainDate,
+      @query(#{ explode: true }) until?: plainDate,
+    ): (OkResponse &
+      Body<{
+        roomChanges: RoomChange[];
+      }>) | UnauthorizedResponse;
+  }
+
   @route("/v1/subjects")
   @tag("Subjects")
   interface SubjectsV1 {


### PR DESCRIPTION
## Summary
- app-bff-api に `CancelledClass`, `MakeupClass`, `RoomChange` モデルを追加（`SubjectSummary` / BFF用 `Room` を使用した軽量版）
- `/v1/cancelledClasses`, `/v1/makeupClasses`, `/v1/roomChanges` の list エンドポイントを追加
- クエリパラメータは academic-api と同一（`subjectIds`, `from`, `until`）

## Test plan
- [x] `task compile` でコンパイル成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)