### PR TITLE
App BFF: 休講・補講・教室変更にBearer Authを追加

### DIFF
--- a/src/app-bff-api/service.tsp
+++ b/src/app-bff-api/service.tsp
@@ -89,6 +89,7 @@ namespace AppBFFService {
       }>) | UnauthorizedResponse;
   }
 
+  @useAuth([BearerAuth, FoundationV1.FirebaseAppCheckAuth])
   @route("/v1/cancelledClasses")
   @tag("CancelledClasses")
   interface CancelledClassesV1 {
@@ -109,6 +110,7 @@ namespace AppBFFService {
       }>) | UnauthorizedResponse;
   }
 
+  @useAuth([BearerAuth, FoundationV1.FirebaseAppCheckAuth])
   @route("/v1/makeupClasses")
   @tag("MakeupClasses")
   interface MakeupClassesV1 {
@@ -129,6 +131,7 @@ namespace AppBFFService {
       }>) | UnauthorizedResponse;
   }
 
+  @useAuth([BearerAuth, FoundationV1.FirebaseAppCheckAuth])
   @route("/v1/roomChanges")
   @tag("RoomChanges")
   interface RoomChangesV1 {


### PR DESCRIPTION
学内情報である休講・補講・教室変更では、Bearer Authを必要とするように変更