### PR TITLE
教員室APIを追加

### DIFF
--- a/src/academic-api/model.tsp
+++ b/src/academic-api/model.tsp
@@ -95,21 +95,21 @@ namespace AcademicService {
 
     /**
      * 部屋番号
-     * 
+     *
      * 部屋番号が存在しない場合は空文字
      */
     number: string;
 
     /**
      * フロア
-     * 
+     *
      * オンラインなどの仮想教室の場合はVirtualを使用
      */
     floor: DottoFoundationV1.Floor;
 
     /**
      * 教員
-     * 
+     *
      * 教員室でない場合は省略
      */
     faculty?: Faculty;
@@ -170,14 +170,14 @@ namespace AcademicService {
 
     /**
      * 授業名末尾の`学年-クラス`をもとに決定
-     * 
+     *
      * 科目詳細取得でのみ必須
      */
     eligibleAttributes?: SubjectTargetClass[];
 
     /**
      * 科目群・科目区分をもとに決定
-     * 
+     *
      * 科目詳細取得でのみ必須
      */
     requirements?: SubjectRequirement[];
@@ -356,5 +356,17 @@ namespace AcademicService {
     subjectId: string;
     slot?: DottoFoundationV1.TimetableSlot;
     roomIds: string[];
+  }
+
+  model FacultyRoom {
+    faculty: Faculty;
+    room: Room;
+    year: integer;
+  }
+
+  model FacultyRoomRequest {
+    facultyId: string;
+    roomId: string;
+    year: integer;
   }
 }

--- a/src/academic-api/model.tsp
+++ b/src/academic-api/model.tsp
@@ -104,6 +104,7 @@ namespace AcademicService {
      * 教員
      *
      * 空室の教員室や教員室でない場合は省略
+     * 基準は現在の年度
      */
     faculty?: Faculty;
   }

--- a/src/academic-api/model.tsp
+++ b/src/academic-api/model.tsp
@@ -94,13 +94,6 @@ namespace AcademicService {
     name: string;
 
     /**
-     * 部屋番号
-     *
-     * 部屋番号が存在しない場合は空文字
-     */
-    number: string;
-
-    /**
      * フロア
      *
      * オンラインなどの仮想教室の場合はVirtualを使用
@@ -110,7 +103,7 @@ namespace AcademicService {
     /**
      * 教員
      *
-     * 教員室でない場合は省略
+     * 空室の教員室や教員室でない場合は省略
      */
     faculty?: Faculty;
   }

--- a/src/academic-api/model.tsp
+++ b/src/academic-api/model.tsp
@@ -118,7 +118,6 @@ namespace AcademicService {
   model RoomRequest {
     name: string;
     floor: DottoFoundationV1.Floor;
-    facultyId?: string;
   }
 
   model Reservation {

--- a/src/academic-api/model.tsp
+++ b/src/academic-api/model.tsp
@@ -359,6 +359,7 @@ namespace AcademicService {
   }
 
   model FacultyRoom {
+    id: string;
     faculty: Faculty;
     room: Room;
     year: integer;

--- a/src/academic-api/service.tsp
+++ b/src/academic-api/service.tsp
@@ -467,4 +467,36 @@ namespace AcademicService {
      */
     @delete delete(@path id: string): NoContentResponse | NotFoundResponse;
   }
+
+  @route("/v1/facultyRooms")
+  @tag("FacultyRooms")
+  interface FacultyRoomsV1 {
+    /**
+     * 教員室を取得する
+     *
+     * @param year 年度; 指定しない場合は今年度が選択される
+     * @returns 教員室のリスト
+     */
+    @get list(@query year?: integer): OkResponse &
+      Body<{
+        facultyRooms: FacultyRoom[];
+      }>;
+
+    /**
+     * 教員室を追加する
+     * @param body 追加する教員室の情報
+     * @returns 作成された教員室
+     */
+    @post create(@body body: FacultyRoomRequest): CreatedResponse &
+      Body<{
+        facultyRoom: FacultyRoom;
+      }>;
+
+    /**
+     * 教員室を削除する
+     * @param id 教員室ID
+     * @returns 削除された教員室
+     */
+    @delete delete(@path id: string): NoContentResponse | NotFoundResponse;
+  }
 }

--- a/src/admin-bff-api/service.tsp
+++ b/src/admin-bff-api/service.tsp
@@ -678,4 +678,38 @@ namespace AdminBFFService {
         menuItems: FunchService.MenuItem[];
       }>) | UnauthorizedResponse;
   }
+
+  @route("/v1/facultyRooms")
+  @tag("FacultyRooms")
+  interface FacultyRoomsV1 {
+    /**
+     * 教員室を取得する
+     *
+     * @param year 年度; 指定しない場合は今年度が選択される
+     * @returns 教員室のリスト
+     */
+    @get list(@query year?: integer): OkResponse &
+      Body<{
+        facultyRooms: AcademicService.FacultyRoom[];
+      }>;
+
+    /**
+     * 教員室を追加する
+     * @param body 追加する教員室の情報
+     * @returns 作成された教員室
+     */
+    @post create(
+      @body body: AcademicService.FacultyRoomRequest,
+    ): CreatedResponse &
+      Body<{
+        facultyRoom: AcademicService.FacultyRoom;
+      }>;
+
+    /**
+     * 教員室を削除する
+     * @param id 教員室ID
+     * @returns 削除された教員室
+     */
+    @delete delete(@path id: string): NoContentResponse | NotFoundResponse;
+  }
 }

--- a/src/admin-bff-api/service.tsp
+++ b/src/admin-bff-api/service.tsp
@@ -688,10 +688,10 @@ namespace AdminBFFService {
      * @param year 年度; 指定しない場合は今年度が選択される
      * @returns 教員室のリスト
      */
-    @get list(@query year?: integer): OkResponse &
+    @get list(@query year?: integer): (OkResponse &
       Body<{
         facultyRooms: AcademicService.FacultyRoom[];
-      }>;
+      }>) | UnauthorizedResponse;
 
     /**
      * 教員室を追加する
@@ -700,16 +700,18 @@ namespace AdminBFFService {
      */
     @post create(
       @body body: AcademicService.FacultyRoomRequest,
-    ): CreatedResponse &
+    ): (CreatedResponse &
       Body<{
         facultyRoom: AcademicService.FacultyRoom;
-      }>;
+      }>) | UnauthorizedResponse;
 
     /**
      * 教員室を削除する
      * @param id 教員室ID
      * @returns 削除された教員室
      */
-    @delete delete(@path id: string): NoContentResponse | NotFoundResponse;
+    @delete delete(
+      @path id: string,
+    ): NoContentResponse | NotFoundResponse | UnauthorizedResponse;
   }
 }

--- a/src/app-bff-api/model.tsp
+++ b/src/app-bff-api/model.tsp
@@ -32,8 +32,31 @@ namespace AppBFFService {
 
   model Room {
     id: string;
+
+    /**
+     * 部屋名
+     */
     name: string;
+
+    /**
+     * フロア
+     *
+     * オンラインなどの仮想教室の場合はVirtualを使用
+     */
     floor: DottoFoundationV1.Floor;
+
+    /**
+     * 教員
+     *
+     * 空室の教員室や教員室でない場合は省略
+     */
+    faculty?: Faculty;
+  }
+
+  model Faculty {
+    id: string;
+    name: string;
+    email: string;
   }
 
   model SubjectDetail {


### PR DESCRIPTION
## 概要

AcademicService と AdminBFFService に教員室（FacultyRoom）を扱うAPIを追加する。あわせて `RoomRequest` から `facultyId` を削除し、教員と部屋の関連付けは `FacultyRoom` 経由に一本化する。

## 変更点

- `src/academic-api/model.tsp`
  - `FacultyRoom` モデル（`id`, `faculty`, `room`, `year`）を追加
  - `FacultyRoomRequest` モデル（`facultyId`, `roomId`, `year`）を追加
  - `RoomRequest` から `facultyId` を削除（教員との紐付けは `FacultyRoom` で表現）
  - 既存コメントの末尾空白を整理
- `src/academic-api/service.tsp`
  - `FacultyRoomsV1` インターフェースを追加し、`/v1/facultyRooms` に対する一覧取得・作成・削除のエンドポイントを定義
  - 一覧取得は `year` クエリで年度指定（省略時は今年度）
- `src/admin-bff-api/service.tsp`
  - Admin BFF 側にも同等の `FacultyRoomsV1` インターフェースを追加し、`AcademicService.FacultyRoom` / `FacultyRoomRequest` を参照

## 確認事項

- [x] `task compile` で TypeSpec のコンパイルが通ること
- [x] 生成される OpenAPI に `/v1/facultyRooms` のエンドポイントが期待どおり出力されること
- [x] `RoomRequest` から `facultyId` を削除したことに伴う下流の利用箇所への影響確認