### PR TITLE
APIスキーマの整理と通知・予約周りの機能追加

### DIFF
--- a/src/academic-api/model.tsp
+++ b/src/academic-api/model.tsp
@@ -116,7 +116,7 @@ namespace AcademicService {
 
   model Reservation {
     id: string;
-    roomId: string;
+    room: Room;
     startAt: utcDateTime;
     endAt: utcDateTime;
     title: string;

--- a/src/academic-api/service.tsp
+++ b/src/academic-api/service.tsp
@@ -310,16 +310,6 @@ namespace AcademicService {
       }>;
 
     /**
-     * 予約を詳細取得する
-     * @param id 予約ID
-     * @returns 予約の詳細
-     */
-    @get detail(@path id: string): (OkResponse &
-      Body<{
-        reservation: Reservation;
-      }>) | NotFoundResponse;
-
-    /**
      * 教室を予約する
      * @param body 予約する教室の情報
      * @returns 作成された予約

--- a/src/academic-api/service.tsp
+++ b/src/academic-api/service.tsp
@@ -156,15 +156,6 @@ namespace AcademicService {
       }>;
 
     /**
-     * 教務システムから休講を取得する
-     * @returns 新たに取得された休講
-     */
-    @put fetch(): OkResponse &
-      Body<{
-        cancelledClasses: CancelledClass[];
-      }>;
-
-    /**
      * 休講を削除する
      * @param id 休講ID
      */
@@ -201,15 +192,6 @@ namespace AcademicService {
       }>;
 
     /**
-     * 教務システムから補講を取得する
-     * @returns 新たに取得された補講
-     */
-    @put fetch(): OkResponse &
-      Body<{
-        makeupClasses: MakeupClass[];
-      }>;
-
-    /**
      * 補講を削除する
      * @param id 補講ID
      */
@@ -243,15 +225,6 @@ namespace AcademicService {
     @post create(@body body: RoomChangeRequest): CreatedResponse &
       Body<{
         roomChange: RoomChange;
-      }>;
-
-    /**
-     * 教務システムから教室変更を取得する
-     * @returns 新たに取得された教室変更
-     */
-    @put fetch(): OkResponse &
-      Body<{
-        roomChanges: RoomChange[];
       }>;
 
     /**

--- a/src/admin-bff-api/service.tsp
+++ b/src/admin-bff-api/service.tsp
@@ -236,8 +236,8 @@ namespace AdminBFFService {
   interface NotificationV1 {
     /**
      * 通知の一覧を取得する
-     * @param notifyAtFrom 通知予定日時の開始日時 (notifyAt >= notifyAtFrom)
-     * @param notifyAtTo 通知予定日時の終了日時 (notifyAt <= notifyAtTo)
+     * @param notifyAtFrom 通知予定期間の開始日時（通知ウィンドウがこの範囲と重なるものを抽出: notifyBefore >= notifyAtFrom）
+     * @param notifyAtTo 通知予定期間の終了日時（通知ウィンドウがこの範囲と重なるものを抽出: notifyAfter <= notifyAtTo）
      * @param isNotified 通知済みかどうか (true: 通知済みの通知のみ、false: 通知未済みの通知のみ、指定なし: 全ての通知)
      * @returns 通知の一覧
      */

--- a/src/admin-bff-api/service.tsp
+++ b/src/admin-bff-api/service.tsp
@@ -464,16 +464,6 @@ namespace AdminBFFService {
       }>) | UnauthorizedResponse;
 
     /**
-     * 予約を詳細取得する
-     * @param id 予約ID
-     * @returns 予約の詳細
-     */
-    @get detail(@path id: string): (OkResponse &
-      Body<{
-        reservation: AcademicService.Reservation;
-      }>) | NotFoundResponse | UnauthorizedResponse;
-
-    /**
      * 教室を予約する
      * @param body 予約する教室の情報
      * @returns 作成された予約

--- a/src/admin-bff-api/service.tsp
+++ b/src/admin-bff-api/service.tsp
@@ -281,6 +281,16 @@ namespace AdminBFFService {
      * @returns
      */
     @delete delete(@path id: string): NoContentResponse | NotFoundResponse;
+
+    /**
+     * 通知キューに溜まっている通知のうち、予定時刻を過ぎている通知をまとめて送信する
+     * @returns 送信された通知の一覧
+     */
+    @route("/dispatch")
+    @post dispatch(): (OkResponse &
+      Body<{
+        notifications: UserService.Notification[];
+      }>) | UnauthorizedResponse;
   }
 
   @route("/v1/makeupClasses")

--- a/src/admin-bff-api/service.tsp
+++ b/src/admin-bff-api/service.tsp
@@ -283,11 +283,16 @@ namespace AdminBFFService {
     @delete delete(@path id: string): NoContentResponse | NotFoundResponse;
 
     /**
-     * 通知キューに溜まっている通知のうち、予定時刻を過ぎている通知をまとめて送信する
+     * 指定したIDの通知を、送信状態や送信可能期間に関わらずまとめて送信する
+     * @param body 送信対象の通知IDリスト
      * @returns 送信された通知の一覧
      */
     @route("/dispatch")
-    @post dispatch(): (OkResponse &
+    @post dispatch(
+      @body body: {
+        notificationIds: string[];
+      },
+    ): (OkResponse &
       Body<{
         notifications: UserService.Notification[];
       }>) | UnauthorizedResponse;

--- a/src/admin-bff-api/service.tsp
+++ b/src/admin-bff-api/service.tsp
@@ -245,10 +245,10 @@ namespace AdminBFFService {
       @query(#{ explode: true }) notifyAtFrom?: utcDateTime,
       @query(#{ explode: true }) notifyAtTo?: utcDateTime,
       @query isNotified?: boolean,
-    ): OkResponse &
+    ): (OkResponse &
       Body<{
         notifications: UserService.Notification[];
-      }>;
+      }>) | UnauthorizedResponse;
 
     /**
      * 通知を作成する
@@ -256,10 +256,12 @@ namespace AdminBFFService {
      * @param body 作成する通知の情報
      * @returns 作成された通知
      */
-    @post create(@body body: UserService.NotificationRequest): CreatedResponse &
+    @post create(
+      @body body: UserService.NotificationRequest,
+    ): (CreatedResponse &
       Body<{
         notification: UserService.Notification;
-      }>;
+      }>) | UnauthorizedResponse;
 
     /**
      * 通知を更新する
@@ -273,7 +275,7 @@ namespace AdminBFFService {
     ): (OkResponse &
       Body<{
         notification: UserService.Notification;
-      }>) | NotFoundResponse;
+      }>) | NotFoundResponse | UnauthorizedResponse;
 
     /**
      * 通知を削除する

--- a/src/admin-bff-api/service.tsp
+++ b/src/admin-bff-api/service.tsp
@@ -223,15 +223,6 @@ namespace AdminBFFService {
       }>) | UnauthorizedResponse;
 
     /**
-     * 教務システムから休講を取得する
-     * @returns 新たに取得された休講
-     */
-    @put fetch(): (OkResponse &
-      Body<{
-        cancelledClasses: AcademicService.CancelledClass[];
-      }>) | UnauthorizedResponse;
-
-    /**
      * 休講を削除する
      * @param id 休講ID
      */
@@ -324,15 +315,6 @@ namespace AdminBFFService {
       }>) | UnauthorizedResponse;
 
     /**
-     * 教務システムから補講を取得する
-     * @returns 新たに取得された補講
-     */
-    @put fetch(): (OkResponse &
-      Body<{
-        makeupClasses: AcademicService.MakeupClass[];
-      }>) | UnauthorizedResponse;
-
-    /**
      * 補講を削除する
      * @param id 補講ID
      */
@@ -370,15 +352,6 @@ namespace AdminBFFService {
     ): (CreatedResponse &
       Body<{
         roomChange: AcademicService.RoomChange;
-      }>) | UnauthorizedResponse;
-
-    /**
-     * 教務システムから教室変更を取得する
-     * @returns 新たに取得された教室変更
-     */
-    @put fetch(): (OkResponse &
-      Body<{
-        roomChanges: AcademicService.RoomChange[];
       }>) | UnauthorizedResponse;
 
     /**

--- a/src/admin-bff-api/service.tsp
+++ b/src/admin-bff-api/service.tsp
@@ -280,12 +280,17 @@ namespace AdminBFFService {
      * @param id 通知ID
      * @returns
      */
-    @delete delete(@path id: string): NoContentResponse | NotFoundResponse;
+    @delete delete(
+      @path id: string,
+    ): NoContentResponse | NotFoundResponse | UnauthorizedResponse;
 
     /**
      * 指定したIDの通知を、送信状態や送信可能期間に関わらずまとめて送信する
+     *
+     * `notificationIds` が空配列の場合は `400 Bad Request` を返す。
+     * 存在しないIDが含まれる場合でもエラーにはせず、送信に成功した通知のみをレスポンスに含める。
      * @param body 送信対象の通知IDリスト
-     * @returns 送信された通知の一覧
+     * @returns 送信に成功した通知の一覧
      */
     @route("/dispatch")
     @post dispatch(
@@ -295,7 +300,7 @@ namespace AdminBFFService {
     ): (OkResponse &
       Body<{
         notifications: UserService.Notification[];
-      }>) | UnauthorizedResponse;
+      }>) | BadRequestResponse | UnauthorizedResponse;
   }
 
   @route("/v1/makeupClasses")

--- a/src/app-bff-api/model.tsp
+++ b/src/app-bff-api/model.tsp
@@ -53,6 +53,14 @@ namespace AppBFFService {
     faculty?: Faculty;
   }
 
+  model Reservation {
+    id: string;
+    room: Room;
+    startAt: utcDateTime;
+    endAt: utcDateTime;
+    title: string;
+  }
+
   model Faculty {
     id: string;
     name: string;

--- a/src/app-bff-api/service.tsp
+++ b/src/app-bff-api/service.tsp
@@ -267,4 +267,25 @@ namespace AppBFFService {
         menuItems: MenuItem[];
       }>) | UnauthorizedResponse;
   }
+
+  @route("/v1/reservations")
+  @tag("Reservations")
+  interface ReservationsV1 {
+    /**
+     * 教室の予約一覧を取得する
+     * 検索対象期間に一部でも重複する予約が取得される
+     * @param roomIds 教室IDのリスト
+     * @param from 検索対象開始日時
+     * @param until 検索対象終了日時
+     * @returns 予約のリスト
+     */
+    @get list(
+      @query roomIds?: string[],
+      @query(#{ explode: true }) from?: utcDateTime,
+      @query(#{ explode: true }) until?: utcDateTime,
+    ): OkResponse &
+      Body<{
+        reservations: Reservation[];
+      }>;
+  }
 }

--- a/src/app-bff-api/service.tsp
+++ b/src/app-bff-api/service.tsp
@@ -283,9 +283,9 @@ namespace AppBFFService {
       @query roomIds?: string[],
       @query(#{ explode: true }) from?: utcDateTime,
       @query(#{ explode: true }) until?: utcDateTime,
-    ): OkResponse &
+    ): (OkResponse &
       Body<{
         reservations: Reservation[];
-      }>;
+      }>) | UnauthorizedResponse;
   }
 }

--- a/src/user-api/model.tsp
+++ b/src/user-api/model.tsp
@@ -76,9 +76,14 @@ namespace UserService {
     url?: string;
 
     /**
-     * 通知予定日時
+     * 通知送信可能になる日時（この時刻以降に送信対象となる）
      */
-    notifyAt: utcDateTime;
+    notifyAfter: utcDateTime;
+
+    /**
+     * 通知送信期限日時（この時刻を過ぎた場合は送信しない）
+     */
+    notifyBefore: utcDateTime;
 
     /**
      * 通知が送信されたかどうか
@@ -95,7 +100,8 @@ namespace UserService {
     title: string;
     message: string;
     url?: string;
-    notifyAt: utcDateTime;
+    notifyAfter: utcDateTime;
+    notifyBefore: utcDateTime;
     targetUserIds: string[];
   }
 }

--- a/src/user-api/service.tsp
+++ b/src/user-api/service.tsp
@@ -135,17 +135,20 @@ namespace UserService {
 
     /**
      * 指定したIDの通知を、送信状態や送信可能期間に関わらずまとめて送信する
+     *
+     * `notificationIds` が空配列の場合は `400 Bad Request` を返す。
+     * 存在しないIDが含まれる場合でもエラーにはせず、送信に成功した通知のみをレスポンスに含める。
      * @param body 送信対象の通知IDリスト
-     * @returns 送信された通知の一覧
+     * @returns 送信に成功した通知の一覧
      */
     @route("/dispatch")
     @post dispatch(
       @body body: {
         notificationIds: string[];
       },
-    ): OkResponse &
+    ): (OkResponse &
       Body<{
         notifications: Notification[];
-      }>;
+      }>) | BadRequestResponse;
   }
 }

--- a/src/user-api/service.tsp
+++ b/src/user-api/service.tsp
@@ -132,5 +132,15 @@ namespace UserService {
      * @returns
      */
     @delete delete(@path id: string): NoContentResponse | NotFoundResponse;
+
+    /**
+     * 通知キューに溜まっている通知のうち、予定時刻を過ぎている通知をまとめて送信する
+     * @returns 送信された通知の一覧
+     */
+    @route("/dispatch")
+    @post dispatch(): OkResponse &
+      Body<{
+        notifications: Notification[];
+      }>;
   }
 }

--- a/src/user-api/service.tsp
+++ b/src/user-api/service.tsp
@@ -134,11 +134,16 @@ namespace UserService {
     @delete delete(@path id: string): NoContentResponse | NotFoundResponse;
 
     /**
-     * 通知キューに溜まっている通知のうち、予定時刻を過ぎている通知をまとめて送信する
+     * 指定したIDの通知を、送信状態や送信可能期間に関わらずまとめて送信する
+     * @param body 送信対象の通知IDリスト
      * @returns 送信された通知の一覧
      */
     @route("/dispatch")
-    @post dispatch(): OkResponse &
+    @post dispatch(
+      @body body: {
+        notificationIds: string[];
+      },
+    ): OkResponse &
       Body<{
         notifications: Notification[];
       }>;

--- a/src/user-api/service.tsp
+++ b/src/user-api/service.tsp
@@ -87,8 +87,8 @@ namespace UserService {
   interface NotificationV1 {
     /**
      * 通知の一覧を取得する
-     * @param notifyAtFrom 通知予定日時の開始日時 (notifyAt >= notifyAtFrom)
-     * @param notifyAtTo 通知予定日時の終了日時 (notifyAt <= notifyAtTo)
+     * @param notifyAtFrom 通知予定期間の開始日時（通知ウィンドウがこの範囲と重なるものを抽出: notifyBefore >= notifyAtFrom）
+     * @param notifyAtTo 通知予定期間の終了日時（通知ウィンドウがこの範囲と重なるものを抽出: notifyAfter <= notifyAtTo）
      * @param isNotified 通知済みかどうか (true: 通知済みの通知のみ、false: 通知未済みの通知のみ、指定なし: 全ての通知)
      * @returns 通知の一覧
      */


### PR DESCRIPTION
## 概要

通知・予約・教務API周りのスキーマ整理と機能追加を行いました。不要になったエンドポイントの削除、モデル構造の見直し、新規APIの追加を含みます。

## 変更点

### 通知API (UserService / AdminBFFService)
- `Notification` の `notifyAt` を、送信可能期間を表す `notifyAfter` / `notifyBefore` の2フィールドに分割
- 通知一覧の検索パラメータ `notifyAtFrom` / `notifyAtTo` を、通知ウィンドウとの重なりを判定するセマンティクスに変更
- 指定したIDの通知をまとめて送信する `POST /dispatch` エンドポイントを UserService / AdminBFFService に追加（送信状態や期間に関わらず送信）

### 予約API
- `AcademicService.Reservation` の `roomId: string` を `room: Room` の埋め込みに変更
- `AcademicService` から予約詳細取得エンドポイント (`GET detail`) を削除
- `AppBFFService` に `Reservation` モデルと、教室予約一覧取得API (`GET /v1/reservations`) を追加（`roomIds` / `from` / `until` による期間検索）

### 教務システム取得エンドポイントの削除
- `AcademicService` / `AdminBFFService` から、教務システムからの取得を行う `PUT fetch` エンドポイントを削除
  - 休講 (cancelledClasses)
  - 補講 (makeupClasses)
  - 教室変更 (roomChanges)

## 確認事項

- [ ] `task compile` が通ること
- [ ] 生成されるOpenAPIスキーマの互換性影響の確認