### PR TITLE
メニュー一覧APIの date クエリに explode: true を指定

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,10 @@
+# Copilot Instructions
+
+## レビューコメント
+
+- レビューコメントは日本語で記述すること。
+
+## クエリパラメータ
+
+- `plainDate`, `utcDateTime`, `plainTime` 型を単体でクエリパラメータに含める場合は、必ず `explode: true` を設定すること。
+- これらの型を配列でクエリパラメータに含める場合は、`explode: true` の設定は不要。

--- a/src/admin-bff-api/service.tsp
+++ b/src/admin-bff-api/service.tsp
@@ -670,7 +670,7 @@ namespace AdminBFFService {
      * @param date メニューを取得する日付
      * @returns メニューのリスト
      */
-    @get list(@query date: plainDate): (OkResponse &
+    @get list(@query(#{ explode: true }) date: plainDate): (OkResponse &
       Body<{
         menuItems: FunchService.MenuItem[];
       }>) | UnauthorizedResponse;

--- a/src/funch-api/service.tsp
+++ b/src/funch-api/service.tsp
@@ -26,7 +26,7 @@ namespace FunchService {
      *
      * @returns メニューのリスト
      */
-    @get list(@query date: plainDate): OkResponse &
+    @get list(@query(#{ explode: true }) date: plainDate): OkResponse &
       Body<{
         menuItems: MenuItem[];
       }>;


### PR DESCRIPTION
## 概要

`FunchService` および `AdminBFFService` のメニュー一覧取得API (`@get list`) における `date` クエリパラメータに `@query(#{ explode: true })` を指定しました。

## 変更点

- `src/funch-api/service.tsp`: `list` の `date` クエリに `explode: true` を付与
- `src/admin-bff-api/service.tsp`: `list` の `date` クエリに `explode: true` を付与

## 背景

`plainDate` 型のクエリパラメータについて OpenAPI 生成時のシリアライズ挙動を明示するため、`explode: true` を指定しています。

## 確認内容

- [ ] `task compile` で OpenAPI が正しく生成されること