### PR TITLE
App BFFの予約一覧エンドポイントをBearerAuthで保護

### DIFF
--- a/src/app-bff-api/service.tsp
+++ b/src/app-bff-api/service.tsp
@@ -268,6 +268,7 @@ namespace AppBFFService {
       }>) | UnauthorizedResponse;
   }
 
+  @useAuth([BearerAuth, FoundationV1.FirebaseAppCheckAuth])
   @route("/v1/reservations")
   @tag("Reservations")
   interface ReservationsV1 {


### PR DESCRIPTION
## 概要

App BFF の `GET /v1/reservations`（予約一覧取得）に `BearerAuth` を追加し、Firebase App Check に加えてユーザー認証を必須化する。

## 背景

App BFF の他の個人向けエンドポイント（履修情報・個人カレンダー・休講補講・教室変更・ユーザー・FCMトークン等）は `@useAuth([BearerAuth, FirebaseAppCheckAuth])` で保護されている一方、`/v1/reservations` は App Check のみで Bearer 保護が欠けていたため揃える。

## 変更内容

- `src/app-bff-api/service.tsp` の `ReservationsV1` インターフェースに `@useAuth([BearerAuth, FoundationV1.FirebaseAppCheckAuth])` を付与。

## 確認事項

- [x] `task compile` が成功すること