### PR TITLE
Notificationモデルにパラメータを追加

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,6 +21,10 @@ tasks:
     desc: Watch for changes and compile
     cmds:
       - "{{.PNPM}} watch"
+  format:
+    desc: Format the code
+    cmds:
+      - "{{.PNPM}} format"
   preview:
     desc: Preview the documentation
     cmds:

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "compile": "tsp compile .",
     "watch": "tsp compile . --watch",
+    "format": "tsp format .",
     "preview": "redocly preview --project-dir=./tsp-output/schema/",
     "build-docs:academic-api": "redocly build-docs academic-api -o ./dist/academic-api.html",
     "build-docs:admin-bff-api": "redocly build-docs admin-bff-api -o ./dist/admin-bff-api.html",

--- a/src/user-api/model.tsp
+++ b/src/user-api/model.tsp
@@ -90,16 +90,16 @@ namespace UserService {
      *
      * 通知の開封率計測などに利用
      */
-     analyticsLabel?: string;
+    analyticsLabel?: string;
 
-     /**
+    /**
      * APNs のバッジ数
      *
      * アプリアイコンに表示される数値。0 でバッジを消去
      */
-     apnsBadge?: int32;
+    apnsBadge?: int32;
 
-     /**
+    /**
      * APNs の通知音
      *
      * - "default": OS 標準の通知音
@@ -107,40 +107,40 @@ namespace UserService {
      * - 任意のファイル名（例: "alert.caf"）: アプリバンドルまたは Library/Sounds/ に同梱されたカスタムサウンド
      *   対応フォーマットは .caf / .aiff / .wav（Linear PCM, MA4, µ-law, a-law）、最大30秒
      */
-     apnsSound?: string;
+    apnsSound?: string;
 
-     /**
+    /**
      * APNs の content-available フラグ
      *
      * true でサイレントプッシュ（バックグラウンド更新）になる
      */
-     apnsContentAvailable?: boolean;
+    apnsContentAvailable?: boolean;
 
-     /**
+    /**
      * Android の通知チャンネルID
      *
      * Android 8.0 以降、通知はチャンネル単位で管理される
      */
-     androidChannelId?: string;
+    androidChannelId?: string;
 
-     /**
+    /**
      * Android の通知優先度
      *
      * "normal" または "high"。"high" は即時配信される
      */
-     androidPriority?: string;
+    androidPriority?: string;
 
-     /**
+    /**
      * Android の通知TTL（秒）
      *
      * FCM がメッセージを保持する最大時間。期限切れで破棄される
      */
-     androidTTLSeconds?: int32;
+    androidTTLSeconds?: int32;
 
-     /**
+    /**
      * Web Push 通知をクリックした際に開くURL
      */
-     webpushLink?: string;
+    webpushLink?: string;
 
     /**
      * 通知をタップした時に開くURL

--- a/src/user-api/model.tsp
+++ b/src/user-api/model.tsp
@@ -83,7 +83,7 @@ namespace UserService {
     /**
      * 通知に表示する画像のURL
      */
-    imageURL?: string;
+    imageUrl?: string;
 
   	/**
   	 * Firebase Analytics に記録する分析ラベル

--- a/src/user-api/model.tsp
+++ b/src/user-api/model.tsp
@@ -65,9 +65,82 @@ namespace UserService {
   }
 
   model Notification {
+    /**
+     * 通知ID
+     */
     id: string;
+
+    /**
+     * 通知タイトル
+     */
     title: string;
-    message: string;
+
+    /**
+     * 通知本文
+     */
+    body: string;
+
+    /**
+     * 通知に表示する画像のURL
+     */
+    imageURL?: string;
+
+  	/**
+  	 * Firebase Analytics に記録する分析ラベル
+  	 *
+  	 * 通知の開封率計測などに利用
+  	 */
+  	analyticsLabel?: string;
+
+  	/**
+  	 * APNs のバッジ数
+  	 *
+  	 * アプリアイコンに表示される数値。0 でバッジを消去
+  	 */
+  	apnsBadge?: int32;
+
+  	/**
+  	 * APNs の通知音
+  	 *
+  	 * - "default": OS 標準の通知音
+  	 * - "" または省略: 無音
+  	 * - 任意のファイル名（例: "alert.caf"）: アプリバンドルまたは Library/Sounds/ に同梱されたカスタムサウンド
+  	 *   対応フォーマットは .caf / .aiff / .wav（Linear PCM, MA4, µ-law, a-law）、最大30秒
+  	 */
+  	apnsSound?: string;
+
+  	/**
+  	 * APNs の content-available フラグ
+  	 *
+  	 * true でサイレントプッシュ（バックグラウンド更新）になる
+  	 */
+  	apnsContentAvailable?: boolean;
+
+  	/**
+  	 * Android の通知チャンネルID
+  	 *
+  	 * Android 8.0 以降、通知はチャンネル単位で管理される
+  	 */
+  	androidChannelID?: string;
+
+  	/**
+  	 * Android の通知優先度
+  	 *
+  	 * "normal" または "high"。"high" は即時配信される
+  	 */
+  	androidPriority?: string;
+
+  	/**
+  	 * Android の通知TTL（秒）
+  	 *
+  	 * FCM がメッセージを保持する最大時間。期限切れで破棄される
+  	 */
+  	androidTTLSeconds?: int32;
+
+  	/**
+  	 * Web Push 通知をクリックした際に開くURL
+  	 */
+  	webpushLink?: string;
 
     /**
      * 通知をタップした時に開くURL
@@ -97,11 +170,85 @@ namespace UserService {
   }
 
   model NotificationRequest {
+    /**
+     * 通知タイトル
+     */
     title: string;
-    message: string;
+
+    /**
+     * 通知本文
+     */
+    body: string;
+
+    /**
+     * 通知に表示する画像のURL
+     */
+    imageURL?: string;
+
+  	/**
+  	 * Firebase Analytics に記録する分析ラベル
+  	 */
+  	analyticsLabel?: string;
+
+  	/**
+  	 * APNs のバッジ数
+  	 */
+  	apnsBadge?: int32;
+
+  	/**
+  	 * APNs の通知音
+  	 *
+  	 * - "default": OS 標準の通知音
+  	 * - "" または省略: 無音
+  	 * - 任意のファイル名（例: "alert.caf"）: アプリバンドルまたは Library/Sounds/ に同梱されたカスタムサウンド
+  	 *   対応フォーマットは .caf / .aiff / .wav（Linear PCM, MA4, µ-law, a-law）、最大30秒
+  	 */
+  	apnsSound?: string;
+
+  	/**
+  	 * APNs の content-available フラグ（true でサイレントプッシュ）
+  	 */
+  	apnsContentAvailable?: boolean;
+
+  	/**
+  	 * Android の通知チャンネルID
+  	 */
+  	androidChannelID?: string;
+
+  	/**
+  	 * Android の通知優先度（"normal" または "high"）
+  	 */
+  	androidPriority?: string;
+
+  	/**
+  	 * Android の通知TTL（秒）
+  	 */
+  	androidTTLSeconds?: int32;
+
+  	/**
+  	 * Web Push 通知をクリックした際に開くURL
+  	 */
+  	webpushLink?: string;
+
+    /**
+     * 通知をタップした時に開くURL
+     * アプリを開くのみの場合はnull
+     */
     url?: string;
+
+    /**
+     * 通知送信可能になる日時（この時刻以降に送信対象となる）
+     */
     notifyAfter: utcDateTime;
+
+    /**
+     * 通知送信期限日時（この時刻を過ぎた場合は送信しない）
+     */
     notifyBefore: utcDateTime;
+
+    /**
+     * 対象ユーザーIDのリスト
+     */
     targetUserIds: string[];
   }
 }

--- a/src/user-api/model.tsp
+++ b/src/user-api/model.tsp
@@ -183,7 +183,7 @@ namespace UserService {
     /**
      * 通知に表示する画像のURL
      */
-    imageURL?: string;
+    imageUrl?: string;
 
   	/**
   	 * Firebase Analytics に記録する分析ラベル
@@ -213,7 +213,7 @@ namespace UserService {
   	/**
   	 * Android の通知チャンネルID
   	 */
-  	androidChannelID?: string;
+  	androidChannelId?: string;
 
   	/**
   	 * Android の通知優先度（"normal" または "high"）

--- a/src/user-api/model.tsp
+++ b/src/user-api/model.tsp
@@ -85,62 +85,62 @@ namespace UserService {
      */
     imageUrl?: string;
 
-  	/**
-  	 * Firebase Analytics に記録する分析ラベル
-  	 *
-  	 * 通知の開封率計測などに利用
-  	 */
-  	analyticsLabel?: string;
+    /**
+     * Firebase Analytics に記録する分析ラベル
+     *
+     * 通知の開封率計測などに利用
+     */
+     analyticsLabel?: string;
 
-  	/**
-  	 * APNs のバッジ数
-  	 *
-  	 * アプリアイコンに表示される数値。0 でバッジを消去
-  	 */
-  	apnsBadge?: int32;
+     /**
+     * APNs のバッジ数
+     *
+     * アプリアイコンに表示される数値。0 でバッジを消去
+     */
+     apnsBadge?: int32;
 
-  	/**
-  	 * APNs の通知音
-  	 *
-  	 * - "default": OS 標準の通知音
-  	 * - "" または省略: 無音
-  	 * - 任意のファイル名（例: "alert.caf"）: アプリバンドルまたは Library/Sounds/ に同梱されたカスタムサウンド
-  	 *   対応フォーマットは .caf / .aiff / .wav（Linear PCM, MA4, µ-law, a-law）、最大30秒
-  	 */
-  	apnsSound?: string;
+     /**
+     * APNs の通知音
+     *
+     * - "default": OS 標準の通知音
+     * - "" または省略: 無音
+     * - 任意のファイル名（例: "alert.caf"）: アプリバンドルまたは Library/Sounds/ に同梱されたカスタムサウンド
+     *   対応フォーマットは .caf / .aiff / .wav（Linear PCM, MA4, µ-law, a-law）、最大30秒
+     */
+     apnsSound?: string;
 
-  	/**
-  	 * APNs の content-available フラグ
-  	 *
-  	 * true でサイレントプッシュ（バックグラウンド更新）になる
-  	 */
-  	apnsContentAvailable?: boolean;
+     /**
+     * APNs の content-available フラグ
+     *
+     * true でサイレントプッシュ（バックグラウンド更新）になる
+     */
+     apnsContentAvailable?: boolean;
 
-  	/**
-  	 * Android の通知チャンネルID
-  	 *
-  	 * Android 8.0 以降、通知はチャンネル単位で管理される
-  	 */
-  	androidChannelId?: string;
+     /**
+     * Android の通知チャンネルID
+     *
+     * Android 8.0 以降、通知はチャンネル単位で管理される
+     */
+     androidChannelId?: string;
 
-  	/**
-  	 * Android の通知優先度
-  	 *
-  	 * "normal" または "high"。"high" は即時配信される
-  	 */
-  	androidPriority?: string;
+     /**
+     * Android の通知優先度
+     *
+     * "normal" または "high"。"high" は即時配信される
+     */
+     androidPriority?: string;
 
-  	/**
-  	 * Android の通知TTL（秒）
-  	 *
-  	 * FCM がメッセージを保持する最大時間。期限切れで破棄される
-  	 */
-  	androidTTLSeconds?: int32;
+     /**
+     * Android の通知TTL（秒）
+     *
+     * FCM がメッセージを保持する最大時間。期限切れで破棄される
+     */
+     androidTTLSeconds?: int32;
 
-  	/**
-  	 * Web Push 通知をクリックした際に開くURL
-  	 */
-  	webpushLink?: string;
+     /**
+     * Web Push 通知をクリックした際に開くURL
+     */
+     webpushLink?: string;
 
     /**
      * 通知をタップした時に開くURL
@@ -185,50 +185,50 @@ namespace UserService {
      */
     imageUrl?: string;
 
-  	/**
-  	 * Firebase Analytics に記録する分析ラベル
-  	 */
-  	analyticsLabel?: string;
+    /**
+    * Firebase Analytics に記録する分析ラベル
+    */
+    analyticsLabel?: string;
 
-  	/**
-  	 * APNs のバッジ数
-  	 */
-  	apnsBadge?: int32;
+    /**
+    * APNs のバッジ数
+    */
+    apnsBadge?: int32;
 
-  	/**
-  	 * APNs の通知音
-  	 *
-  	 * - "default": OS 標準の通知音
-  	 * - "" または省略: 無音
-  	 * - 任意のファイル名（例: "alert.caf"）: アプリバンドルまたは Library/Sounds/ に同梱されたカスタムサウンド
-  	 *   対応フォーマットは .caf / .aiff / .wav（Linear PCM, MA4, µ-law, a-law）、最大30秒
-  	 */
-  	apnsSound?: string;
+    /**
+    * APNs の通知音
+    *
+    * - "default": OS 標準の通知音
+    * - "" または省略: 無音
+    * - 任意のファイル名（例: "alert.caf"）: アプリバンドルまたは Library/Sounds/ に同梱されたカスタムサウンド
+    *   対応フォーマットは .caf / .aiff / .wav（Linear PCM, MA4, µ-law, a-law）、最大30秒
+    */
+    apnsSound?: string;
 
-  	/**
-  	 * APNs の content-available フラグ（true でサイレントプッシュ）
-  	 */
-  	apnsContentAvailable?: boolean;
+    /**
+    * APNs の content-available フラグ（true でサイレントプッシュ）
+    */
+    apnsContentAvailable?: boolean;
 
-  	/**
-  	 * Android の通知チャンネルID
-  	 */
-  	androidChannelId?: string;
+    /**
+    * Android の通知チャンネルID
+    */
+    androidChannelId?: string;
 
-  	/**
-  	 * Android の通知優先度（"normal" または "high"）
-  	 */
-  	androidPriority?: string;
+    /**
+    * Android の通知優先度（"normal" または "high"）
+    */
+    androidPriority?: string;
 
-  	/**
-  	 * Android の通知TTL（秒）
-  	 */
-  	androidTTLSeconds?: int32;
+    /**
+    * Android の通知TTL（秒）
+    */
+    androidTTLSeconds?: int32;
 
-  	/**
-  	 * Web Push 通知をクリックした際に開くURL
-  	 */
-  	webpushLink?: string;
+    /**
+    * Web Push 通知をクリックした際に開くURL
+    */
+    webpushLink?: string;
 
     /**
      * 通知をタップした時に開くURL

--- a/src/user-api/model.tsp
+++ b/src/user-api/model.tsp
@@ -121,7 +121,7 @@ namespace UserService {
   	 *
   	 * Android 8.0 以降、通知はチャンネル単位で管理される
   	 */
-  	androidChannelID?: string;
+  	androidChannelId?: string;
 
   	/**
   	 * Android の通知優先度

--- a/src/user-api/model.tsp
+++ b/src/user-api/model.tsp
@@ -186,48 +186,48 @@ namespace UserService {
     imageUrl?: string;
 
     /**
-    * Firebase Analytics に記録する分析ラベル
-    */
+     * Firebase Analytics に記録する分析ラベル
+     */
     analyticsLabel?: string;
 
     /**
-    * APNs のバッジ数
-    */
+     * APNs のバッジ数
+     */
     apnsBadge?: int32;
 
     /**
-    * APNs の通知音
-    *
-    * - "default": OS 標準の通知音
-    * - "" または省略: 無音
-    * - 任意のファイル名（例: "alert.caf"）: アプリバンドルまたは Library/Sounds/ に同梱されたカスタムサウンド
-    *   対応フォーマットは .caf / .aiff / .wav（Linear PCM, MA4, µ-law, a-law）、最大30秒
-    */
+     * APNs の通知音
+     *
+     * - "default": OS 標準の通知音
+     * - "" または省略: 無音
+     * - 任意のファイル名（例: "alert.caf"）: アプリバンドルまたは Library/Sounds/ に同梱されたカスタムサウンド
+     *   対応フォーマットは .caf / .aiff / .wav（Linear PCM, MA4, µ-law, a-law）、最大30秒
+     */
     apnsSound?: string;
 
     /**
-    * APNs の content-available フラグ（true でサイレントプッシュ）
-    */
+     * APNs の content-available フラグ（true でサイレントプッシュ）
+     */
     apnsContentAvailable?: boolean;
 
     /**
-    * Android の通知チャンネルID
-    */
+     * Android の通知チャンネルID
+     */
     androidChannelId?: string;
 
     /**
-    * Android の通知優先度（"normal" または "high"）
-    */
+     * Android の通知優先度（"normal" または "high"）
+     */
     androidPriority?: string;
 
     /**
-    * Android の通知TTL（秒）
-    */
+     * Android の通知TTL（秒）
+     */
     androidTTLSeconds?: int32;
 
     /**
-    * Web Push 通知をクリックした際に開くURL
-    */
+     * Web Push 通知をクリックした際に開くURL
+     */
     webpushLink?: string;
 
     /**

--- a/src/user-api/model.tsp
+++ b/src/user-api/model.tsp
@@ -135,7 +135,7 @@ namespace UserService {
      *
      * FCM がメッセージを保持する最大時間。期限切れで破棄される
      */
-    androidTTLSeconds?: int32;
+    androidTtlSeconds?: int32;
 
     /**
      * Web Push 通知をクリックした際に開くURL
@@ -144,7 +144,7 @@ namespace UserService {
 
     /**
      * 通知をタップした時に開くURL
-     * アプリを開くのみの場合はnull
+     * アプリを開くのみの場合は未指定
      */
     url?: string;
 
@@ -223,7 +223,7 @@ namespace UserService {
     /**
      * Android の通知TTL（秒）
      */
-    androidTTLSeconds?: int32;
+    androidTtlSeconds?: int32;
 
     /**
      * Web Push 通知をクリックした際に開くURL
@@ -232,7 +232,7 @@ namespace UserService {
 
     /**
      * 通知をタップした時に開くURL
-     * アプリを開くのみの場合はnull
+     * アプリを開くのみの場合は未指定
      */
     url?: string;
 


### PR DESCRIPTION
## 概要

`src/user-api/model.tsp` の `Notification` / `NotificationRequest` モデルに、各フィールドの意味・取りうる値を説明する日本語のドキュメントコメントを追加しました。

## 変更点

- `Notification` / `NotificationRequest` の各フィールドに `/** */` ドキュメントコメントを追加
  - `imageURL`, `analyticsLabel`, `apnsBadge`, `apnsSound`, `apnsContentAvailable`, `androidChannelID`, `androidPriority`, `androidTTLSeconds`, `webpushLink` などの APNs / Android / Web Push 向けパラメータの用途を明記
  - 特に `apnsSound` については `"default"` / 空文字 / カスタムサウンドファイル名の使い分け、対応フォーマット、長さ上限を記載

## 確認内容

- `task compile` で OpenAPI スキーマのコンパイルが成功することを確認
- 現状，Admin以外で使用していないので，後方互換性は無視します