### PR TITLE
通知済みかどうかをユーザーごとに通知日時で管理するように変更

### DIFF
--- a/src/user-api/model.tsp
+++ b/src/user-api/model.tsp
@@ -159,14 +159,23 @@ namespace UserService {
     notifyBefore: utcDateTime;
 
     /**
-     * 通知が送信されたかどうか
+     * 対象ユーザーのリスト
      */
-    isNotified: boolean;
+    targetUsers: NotificationTargetUser[];
+  }
+
+  model NotificationTargetUser {
+    /**
+     * ユーザーID
+     */
+    userId: string;
 
     /**
-     * 対象ユーザーIDのリスト
+     * 通知送信日時
+     *
+     * 通知が送信された日時。送信前は null
      */
-    targetUserIds: string[];
+    notifiedAt?: utcDateTime;
   }
 
   model NotificationRequest {


### PR DESCRIPTION
# やったこと

- 通知済みかどうかをユーザーごとに通知日時で管理するように変更
  - NotificaitonTargetUserモデルを作成
    - ユーザーIDと通知送信日時（オプショナル）を追加
  - Notificationモデルから通知済みフラグを削除